### PR TITLE
Upgrade Java

### DIFF
--- a/src/install/tools/circuitsimJava.sh
+++ b/src/install/tools/circuitsimJava.sh
@@ -5,14 +5,12 @@ set -e
 echo "Install circuitsim"
 apt-get update && apt-get install -y xserver-xorg-video-dummy
 
-# apt-get update && apt-get install -y openjdk-8-jre openjfx=8u161-b12-1ubuntu2 libopenjfx-java=8u161-b12-1ubuntu2 libopenjfx-jni=8u161-b12-1ubuntu2
-
 # Ubuntu removed openjfx=8u161-b12-1ubuntu2, so we have to install this directly
 # from a .deb now
 # OpenJDK + JFX (https://www.azul.com/downloads/zulu-community/)
 
 apt-get install -y java-common libgl1-mesa-glx
-wget -P $INST_SCRIPTS/pkgs https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_amd64.deb
-dpkg -i $INST_SCRIPTS/pkgs/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_amd64.deb
-rm $INST_SCRIPTS/pkgs/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_amd64.deb
+wget -P $INST_SCRIPTS/pkgs https://cdn.azul.com/zulu/bin/zulu15.29.15-ca-fx-jdk15.0.2-linux_amd64.deb
+dpkg -i $INST_SCRIPTS/pkgs/zulu15.29.15-ca-fx-jdk15.0.2-linux_amd64.deb
+rm $INST_SCRIPTS/pkgs/zulu15.29.15-ca-fx-jdk15.0.2-linux_amd64.deb
 


### PR DESCRIPTION
This is a buffer while we test if upgrading to Python 3 and Java 14 breaks anything important, such as our autograders. CircuitSim has been updated to the new Java 14 version, along with some minor cosmetic fixes from the fork. Since Python 3 is the default now, some applications broke. `websockify` stopped the server from starting properly due to a shebang; upgrading it and adding `python-is-python3` let the server start but may break other packages still relying on Python 2.